### PR TITLE
build: rename inforit to frontliners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.0.0]
 
+- [BREAKING] Renamed Inforit to Frontliners
 - [BREAKING] Updated to NET 8 SDK container
 - Added NET 7 runtime so NET 7 projects can still run (for example the multi target nuget package tests)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-1-bookworm-slim-amd64
 
 # "install" the dotnet 7 runtime so we can also run the NET 7 tests
-COPY --from=mcr.microsoft.com/dotnet/sdk:7.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/sdk:7.0.404-1-bookworm-slim-amd64 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 # install base software
 RUN mkdir -p /usr/share/man/man1 \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 INFORIT
+Copyright (c) 2019 FRONTLINERS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitbucket-pipelines dotnet-build
 
-[![logo](./logo.jpg)](https://inforit.nl)
+[![logo](./logo.jpg)](https://frontliners.nl)
 
 Docker image to automate dotnet builds
 
@@ -28,7 +28,7 @@ Docker image to automate dotnet builds
 ## Usage
 
 ```sh
-image: inforitnl/dotnet-build
+image: frontliners/dotnet-build
 
 pipelines:
   default:

--- a/dotnet-build.sh
+++ b/dotnet-build.sh
@@ -19,9 +19,9 @@ fi
 if [ -n "$MYGET_ACCESS_TOKEN" ]; then
   NUGET_CONFIG=~/.nuget/NuGet/NuGet.Config
   echo "Adding private myget source"
-  SOURCE="https://www.myget.org/F/inforit/auth/$MYGET_ACCESS_TOKEN/api/v3/index.json"
+  SOURCE="https://www.myget.org/F/frontliners/auth/$MYGET_ACCESS_TOKEN/api/v3/index.json"
   if ! grep -q "$SOURCE" $NUGET_CONFIG; then
-    VAR=$(sed "/<\/packageSources>/i <add key=\"Inforit MyGet package source\" value=\"$SOURCE\" protocolVersion=\"3\" />" $NUGET_CONFIG)
+    VAR=$(sed "/<\/packageSources>/i <add key=\"Frontliners MyGet package source\" value=\"$SOURCE\" protocolVersion=\"3\" />" $NUGET_CONFIG)
     echo "$VAR" >$NUGET_CONFIG
   fi
 fi

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "dotnet-build",
   "version": "11.0.0",
-  "description": "[![logo](./logo.jpg)](https://inforit.nl)",
+  "description": "[![logo](./logo.jpg)](https://frontliners.nl)",
   "main": "index.js",
   "scripts": {
-    "build": "docker build -t inforitnl/dotnet-build .",
-    "tag": "docker tag inforitnl/dotnet-build",
-    "push": "docker push inforitnl/dotnet-build",
-    "publish": "DOCKER_PROD_TAG=$(cat package.json | grep version | head -1  | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]') && docker build -t inforitnl/dotnet-build . && docker tag inforitnl/dotnet-build inforitnl/dotnet-build:latest && docker tag inforitnl/dotnet-build inforitnl/dotnet-build:$DOCKER_PROD_TAG  && docker push inforitnl/dotnet-build:latest && docker push inforitnl/dotnet-build:$DOCKER_PROD_TAG"
+    "build": "docker build -t frontliners/dotnet-build .",
+    "tag": "docker tag frontliners/dotnet-build",
+    "push": "docker push frontliners/dotnet-build",
+    "publish": "DOCKER_PROD_TAG=$(cat package.json | grep version | head -1  | awk -F: '{ print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]') && docker build -t frontliners/dotnet-build . && docker tag frontliners/dotnet-build frontliners/dotnet-build:latest && docker tag frontliners/dotnet-build frontliners/dotnet-build:$DOCKER_PROD_TAG && docker push frontliners/dotnet-build:latest && docker push frontliners/dotnet-build:$DOCKER_PROD_TAG"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Inforitnl/dotnet-build.git"
+    "url": "git+https://github.com/frontlinersnl/dotnet-build.git"
   },
   "author": "Rick van Lieshout <info@rickvanlieshout.com> (http://rickvanlieshout.com)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Inforitnl/dotnet-build/issues"
+    "url": "https://github.com/frontlinersnl/dotnet-build/issues"
   },
-  "homepage": "https://github.com/Inforitnl/dotnet-build#readme"
+  "homepage": "https://github.com/frontlinersnl/dotnet-build#readme"
 }


### PR DESCRIPTION
Rename Inforit to Frontliners

Did not change version because I thought to combine this change together with the NET8 upgrade