### PR TITLE
Update docker compose to 2.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.1]
+
+- Update Docker Compose to v2.35.1
+  - Done to allow `pull_policy` of `Daily`
+
 ## [12.0.0]
 
 - Updated to NET 9 SDK Container

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install docker-compose
-RUN curl -L "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+RUN curl -L "https://github.com/docker/compose/releases/download/v2.35.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
   && chmod +x /usr/local/bin/docker-compose
 
 # install Chromium for (unit)-testing during build-phase

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotnet-build",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dotnet-build",
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-build",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "[![logo](./logo.jpg)](https://frontliners.nl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull-request was made because of the missing docker compose feature to set the `pull_policy` to `daily`.

This was introduced in `2.34.0`.

ci: updated docker compose to 2.35.1